### PR TITLE
Feat: Mute specific topics in Clarinete Step

### DIFF
--- a/Sources/MorningBot/Models/ScriptConfig.swift
+++ b/Sources/MorningBot/Models/ScriptConfig.swift
@@ -29,6 +29,7 @@ enum ScriptConfig: Decodable {
     }
 
     enum ClarineteCodingKeys: String, CodingKey {
+        case muteTopics = "mute_topics"
         case limit
     }
 
@@ -49,7 +50,15 @@ enum ScriptConfig: Decodable {
         case .clarineteNews:
             let clarineteContainer = try decoder.container(keyedBy: ClarineteCodingKeys.self)
             let limit = try clarineteContainer.decode(Int.self, forKey: .limit)
-            self = .clarineteNews(ClarineteStep(limit: limit, shouldNotify: notify))
+            let muteTopics = try clarineteContainer.decodeIfPresent([String].self, forKey: .muteTopics) ?? []
+
+            let step = ClarineteStep(
+                muteTopics: muteTopics,
+                limit: limit,
+                shouldNotify: notify
+            )
+            
+            self = .clarineteNews(step)
 
         case .dollar:
             self = .dollar(try DollarStep(shouldNotify: notify))

--- a/Sources/MorningBot/Resources/config.json
+++ b/Sources/MorningBot/Resources/config.json
@@ -14,6 +14,7 @@
         {
             "type": "clarinete_news",
             "limit": 5,
+            "mute_topics": ["Messi"],
             "notify": false
         }
     ],


### PR DESCRIPTION
This feature allows users to mute topics from Clarinete.

For example:

```
{
    "type": "clarinete_news",
    "limit": 5,
    "mute_topics": ["Messi"],
    "notify": false
}
```

This will mute any trending topic that has Messi as related topic.